### PR TITLE
Reactによるmarkdown（一時更新凍結）

### DIFF
--- a/app/javascript/components/preview.jsx
+++ b/app/javascript/components/preview.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react'
 import styled from 'styled-components'
 import * as ReactMarkdown from 'react-markdown'
 import { useStateWithStorage } from '../packs/hooks/use_state_with_storage'
-import * as PropTypes from 'prop-types'
+import PropTypes from 'prop-types'
 
 export default class ArticlePreview extends Component {
   constructor(props) {
@@ -143,12 +143,12 @@ const Preview = styled.div`
 `
 
 ArticlePreview.defaultProps = {
-   article: null
- }
+    article: null
+  }
 
 ArticlePreview.propTypes = {
-  article: PropTypes.object.isRequired
-}
+   article: PropTypes.object.isRequired
+ }
 
 
 

--- a/app/javascript/components/previewts.tsx
+++ b/app/javascript/components/previewts.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components'
 import * as ReactMarkdown from 'react-markdown'
 import { useStateWithStorage } from '../packs/hooks/use_state_with_storage'
 
-export default class ArticlePreview extends React.Component {
+class ArticlePreview extends React.Component {
 
   render() {
     return (
@@ -132,8 +132,10 @@ const Preview = styled.div`
 `
 
 
+interface ArticlePreview{
+  article: Proptypes.object.isRequired
+}
 
 
-
-
+export default ArticlePreview
 

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -5,6 +5,6 @@
     <%= render 'shared/sidebar'%>
   </div>
   <div class="main-contents">
-    <%=  react_component("preview", article: @article.attributes) %>
+    <%=  react_component("previewts", article: @article.attributes) %>
   </div>
 </div>


### PR DESCRIPTION
##What
jsxのプレビューをTSXファイルを使う方法に変更した。


##Why
jsxではコンパイルに失敗し、プレビューを適切に読み込む方法を見つけられなかったため（バベルやmanifest.jsonのプロパティの確認・修正は行ったが、問題が解決せず。過去事例からでは解決方法は判明しなかった）。
TypeScriptを使った場合の型付けの方法・Ruby、Railsから、tsxファイルのPropに変数の引き渡しを行う方法が確認できていないため、これらの方法の学習を行ってから再スタートする予定。

